### PR TITLE
[RFR] Rename to `configurable.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "configurable",
+  "name": "configurable.js",
   "version": "0.1.0",
   "description": "Make a function configurable",
   "main": "configurable.js",


### PR DESCRIPTION
As `configurable` is already taken on npm:

``` 
jpetitcolas@jpetitcolas-marmelab ~/dev/EventDrops $ npm info configurable
 
{ name: 'configurable',
  description: 'Configuration mixin',
  'dist-tags': { latest: '0.0.1' },
  versions: '0.0.1',
  maintainers: 'tjholowaychuk <tj@vision-media.ca>',
  time: 
   { modified: '2012-09-12T12:41:55.384Z',
     created: '2012-06-28T01:25:46.404Z',
     '0.0.1': '2012-06-28T01:25:47.849Z' },
  author: 'TJ Holowaychuk <tj@vision-media.ca>',
  users: {},
  version: '0.0.1',
  keywords: 'configuration',
  dependencies: {},
  devDependencies: { mocha: '*', should: '*' },
  main: 'index',
  dist: 
   { shasum: '47d75b727b51b4eb84c1dadafe3f8240313833b1',
     tarball: 'http://registry.npmjs.org/configurable/-/configurable-0.0.1.tgz' },
  directories: {} }
```

We should then consider publishing it on npm, as we need it on [EventDrops](https://github.com/marmelab/EventDrops/pull/62).